### PR TITLE
Added missing author

### DIFF
--- a/_data/papers.yml
+++ b/_data/papers.yml
@@ -13,7 +13,7 @@
 - title: Dynamics-Aware Unsupervised Skill Learning
   authors: Archit Sharma, Shixiang Gu, Karol Hausman, Sergey Levine, Vikash Kumar
 - title: Hierarchical Policy Learning is Sensitive to Goal Space Design
-  authors: Zach Dwiel, Madhavun Candadai, Mariano Phielipp
+  authors: Zach Dwiel, Madhavun Candadai, Mariano Phielipp, Arjun Bansal
 - title: Unsupervised Discovery of Decision States through Intrinsic Control
   authors: Nirbhay Modhe, Mohit Sharma, Prithvijit Chattopadhyay, Abhishek Das, Devi Parikh, Dhruv Batra, Ramakrishna Vedantam
 - title: Insights on Visual Representations for Embodied Navigation Tasks


### PR DESCRIPTION
The author list for our paper includes as the last author “Arjun Bansal”, but his name is not included in the workshop website’s list of accepted papers. I checked to see that Microsoft CMT lists his name and it does. The complete listing should look like this

Hierarchical Policy Learning is Sensitive to Goal Space Design
Zach Dwiel, Madhavun Candadai, Mariano Phielipp, Arjun Bansal

Thanks!